### PR TITLE
Add upstream Noir tracking workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,12 @@ jobs:
           bun-version: 1.3.6
       - run: bun install --frozen-lockfile
       - run: bun run test
+  upstream-corpus:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.6
+      - run: bun install --frozen-lockfile
+      - run: bun run test:upstream-corpus

--- a/.github/workflows/upstream-canary.yml
+++ b/.github/workflows/upstream-canary.yml
@@ -1,0 +1,59 @@
+name: upstream-canary
+on:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.6
+      - run: bun install --frozen-lockfile
+      - run: git clone --depth 1 https://github.com/noir-lang/noir.git /tmp/tree-sitter-noir-upstream
+      - id: canary
+        continue-on-error: true
+        run: node scripts/check-upstream-corpus.js --source /tmp/tree-sitter-noir-upstream --label upstream-master --report /tmp/upstream-canary-report.json
+      - if: always()
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const reportPath = "/tmp/upstream-canary-report.json";
+
+            if (!fs.existsSync(reportPath)) {
+              console.log("::warning::Upstream canary did not produce a report.");
+              process.exit(0);
+            }
+
+            const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+            const successRate = ((report.successfulCount / report.fileCount) * 100).toFixed(1);
+            const lines = [
+              "## Upstream Noir Canary",
+              "",
+              `- Commit: \`${report.commit}\``,
+              `- Parsed successfully: ${report.successfulCount}/${report.fileCount} (${successRate}%)`,
+              `- Failures: ${report.failureCount}`,
+            ];
+
+            if (report.failures.length > 0) {
+              lines.push("");
+              lines.push("First failures:");
+
+              for (const failure of report.failures.slice(0, 10)) {
+                lines.push(`- \`${failure.file}\` (${failure.start.row}:${failure.start.column} - ${failure.end.row}:${failure.end.column})`);
+              }
+
+              console.log(`::warning::Upstream canary found ${report.failureCount} parse failures against ${report.commit}.`);
+            }
+
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join("\n")}\n`);
+          '
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upstream-noir-canary-report
+          path: /tmp/upstream-canary-report.json
+          if-no-files-found: ignore

--- a/.github/workflows/upstream-canary.yml
+++ b/.github/workflows/upstream-canary.yml
@@ -16,41 +16,9 @@ jobs:
       - run: git clone --depth 1 https://github.com/noir-lang/noir.git /tmp/tree-sitter-noir-upstream
       - id: canary
         continue-on-error: true
-        run: node scripts/check-upstream-corpus.js --source /tmp/tree-sitter-noir-upstream --label upstream-master --report /tmp/upstream-canary-report.json
+        run: bun scripts/check-upstream-corpus.js --source /tmp/tree-sitter-noir-upstream --label upstream-master --report /tmp/upstream-canary-report.json
       - if: always()
-        run: |
-          node -e '
-            const fs = require("node:fs");
-            const reportPath = "/tmp/upstream-canary-report.json";
-
-            if (!fs.existsSync(reportPath)) {
-              console.log("::warning::Upstream canary did not produce a report.");
-              process.exit(0);
-            }
-
-            const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
-            const successRate = ((report.successfulCount / report.fileCount) * 100).toFixed(1);
-            const lines = [
-              "## Upstream Noir Canary",
-              "",
-              `- Commit: \`${report.commit}\``,
-              `- Parsed successfully: ${report.successfulCount}/${report.fileCount} (${successRate}%)`,
-              `- Failures: ${report.failureCount}`,
-            ];
-
-            if (report.failures.length > 0) {
-              lines.push("");
-              lines.push("First failures:");
-
-              for (const failure of report.failures.slice(0, 10)) {
-                lines.push(`- \`${failure.file}\` (${failure.start.row}:${failure.start.column} - ${failure.end.row}:${failure.end.column})`);
-              }
-
-              console.log(`::warning::Upstream canary found ${report.failureCount} parse failures against ${report.commit}.`);
-            }
-
-            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join("\n")}\n`);
-          '
+        run: bun scripts/write-upstream-canary-summary.js --report /tmp/upstream-canary-report.json
       - if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .idea
 *.log
+.nvimlog
 tmp/
 
 *.tern-port
@@ -13,3 +14,5 @@ bun-debug.log*
 
 build/
 target/
+parser.so
+test/upstream-corpus/noir/*/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing
+
+Contributions to `tree-sitter-noir` are welcome. If you find a bug, notice a
+syntax regression, or want to improve the queries, open an issue or send a pull
+request.
+
+## Setup
+
+This repository uses Bun for dependency management and script execution.
+
+```shell
+bun install
+bun run generate
+bun run test
+```
+
+## Development Workflow
+
+Use the regular parser test suite while working on grammar or query changes:
+
+```shell
+bun run test
+```
+
+When you update the pinned upstream Noir manifest or touch the upstream tracking
+scripts, also run:
+
+```shell
+bun run test:upstream-corpus
+```
+
+## Tracking Noir Upstream
+
+Noir does not currently publish a standalone language specification, so this
+repository treats the upstream `noir-lang/noir` repository as the source of
+truth for syntax changes.
+
+The repo tracks upstream in two ways:
+
+- A pinned manifest lives at `test/upstream-corpus/noir/manifest.json`.
+- A scheduled GitHub Actions canary checks the current upstream Noir repository
+  and publishes a drift report.
+
+No upstream Noir sources are committed to this repository. The pinned manifest
+records:
+
+- the upstream commit
+- the parse-clean files to validate at that commit
+- the upstream files that still fail to parse
+
+## Refreshing The Pinned Manifest
+
+To sync from the default upstream repository:
+
+```shell
+bun run sync:upstream-noir
+```
+
+To sync from an existing local checkout of `noir-lang/noir`:
+
+```shell
+node scripts/sync-upstream-noir.js --source /path/to/noir
+```
+
+After refreshing the manifest:
+
+1. Review `test/upstream-corpus/noir/manifest.json`.
+2. Run `bun run test`.
+3. Run `bun run test:upstream-corpus`.
+4. If the sync exposed new syntax that should be supported, reduce it to a
+   focused corpus test before changing the grammar.
+
+## CI Expectations
+
+Pull requests are expected to pass:
+
+- `bun run test`
+- `bun run test:upstream-corpus`
+
+The scheduled `upstream-canary` workflow is informational. It checks the full
+current upstream Noir corpus, uploads a JSON report artifact, and writes a job
+summary so parser drift stays visible without breaking required CI.
+
+The pinned upstream-corpus check downloads the upstream Noir repository at the
+commit recorded in the manifest, builds the current parser locally, and then
+runs the parse check against that downloaded checkout.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ bun run sync:upstream-noir
 To sync from an existing local checkout of `noir-lang/noir`:
 
 ```shell
-node scripts/sync-upstream-noir.js --source /path/to/noir
+bun scripts/sync-upstream-noir.js --source /path/to/noir
 ```
 
 After refreshing the manifest:

--- a/README.md
+++ b/README.md
@@ -109,4 +109,4 @@ No upstream Noir sources are committed to this repository. The pinned manifest
 intentionally targets `examples`, `noir_stdlib`, and the success-oriented
 `test_programs` directories. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the
 sync command, validation steps, and CI expectations around keeping this manifest
-up to date.
+up to date, including the Bun-based direct maintenance commands.

--- a/README.md
+++ b/README.md
@@ -76,10 +76,37 @@ cargo add tree-sitter-noir
 
 Contributions to tree-sitter-noir are welcome. If you find any issues or have suggestions for improvement, please create a new issue or submit a pull request on the [GitHub repository](https://github.com/hhamud/tree-sitter-noir).
 
+Contributor setup, testing expectations, and the upstream Noir sync workflow are documented in [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 Install dependencies with Bun and use Bun to run the project scripts:
 
 ```shell
 bun install
 bun run generate
 bun run test
+bun run test:upstream-corpus
+bun run sync:upstream-noir
 ```
+
+## Tracking Noir Upstream
+
+Noir does not currently publish a standalone language specification, so this
+grammar treats the upstream `noir-lang/noir` repository as the source of truth
+for syntax changes.
+
+This repository now tracks upstream in two ways:
+
+- A pinned manifest lives at `test/upstream-corpus/noir/manifest.json`. It
+  records an upstream Noir commit plus the parse-clean file list to check
+  against that commit. Required CI downloads that pinned upstream revision and
+  runs `bun run test:upstream-corpus` against it.
+- A scheduled GitHub Actions canary clones the latest upstream Noir repository
+  and runs the parser against the full current upstream corpus. The canary is
+  informational: it uploads a JSON report and writes a job summary so grammar
+  drift stays visible without breaking required CI.
+
+No upstream Noir sources are committed to this repository. The pinned manifest
+intentionally targets `examples`, `noir_stdlib`, and the success-oriented
+`test_programs` directories. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the
+sync command, validation steps, and CI expectations around keeping this manifest
+up to date.

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
   "scripts": {
     "install": "node scripts/install.js",
     "test": "tree-sitter generate && tree-sitter test",
+    "test:upstream-corpus": "node scripts/check-upstream-corpus.js",
     "format": "prettier --write \"**/*.{js,json}\"",
-    "generate": "tree-sitter generate"
+    "generate": "tree-sitter generate",
+    "sync:upstream-noir": "node scripts/sync-upstream-noir.js"
   },
   "tree-sitter": [
     {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   "scripts": {
     "install": "node scripts/install.js",
     "test": "tree-sitter generate && tree-sitter test",
-    "test:upstream-corpus": "node scripts/check-upstream-corpus.js",
+    "test:upstream-corpus": "bun scripts/check-upstream-corpus.js",
     "format": "prettier --write \"**/*.{js,json}\"",
     "generate": "tree-sitter generate",
-    "sync:upstream-noir": "node scripts/sync-upstream-noir.js"
+    "sync:upstream-noir": "bun scripts/sync-upstream-noir.js"
   },
   "tree-sitter": [
     {

--- a/scripts/check-upstream-corpus.js
+++ b/scripts/check-upstream-corpus.js
@@ -1,0 +1,100 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  DEFAULT_UPSTREAM_REPO,
+  MANIFEST_PATH,
+  cloneUpstreamRepo,
+  collectManifestFiles,
+  collectNoirFiles,
+  getGitRevision,
+  loadManifest,
+  parseArgs,
+  parseNoirFiles,
+  writeJson,
+} = require("./upstream-noir");
+
+function gatherTargets(args) {
+  if (args.source) {
+    const sourceRoot = path.resolve(args.source);
+    const commit = fs.existsSync(path.join(sourceRoot, ".git"))
+      ? getGitRevision(sourceRoot)
+      : "unknown";
+    const files = collectNoirFiles(sourceRoot);
+
+    return {
+      label: args.label || `upstream-${commit}`,
+      commit,
+      files: files.map((file) => ({
+        absolutePath: file.absolutePath,
+        relativePath: file.relativePath,
+        sourceGroup: file.sourceGroup,
+      })),
+    };
+  }
+
+  const manifest = loadManifest(MANIFEST_PATH);
+  const sourceRoot = cloneUpstreamRepo({
+    repoUrl: manifest.upstream.repo || DEFAULT_UPSTREAM_REPO,
+    ref: manifest.upstream.commit,
+  });
+
+  return {
+    label: args.label || `snapshot-${manifest.upstream.commit}`,
+    cleanupRoot: sourceRoot,
+    commit: manifest.upstream.commit,
+    files: collectManifestFiles(sourceRoot, manifest),
+  };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  let target;
+
+  try {
+    target = gatherTargets(args);
+
+    if (target.files.length === 0) {
+      throw new Error(`No Noir files found for ${target.label}`);
+    }
+
+    const result = parseNoirFiles(target.files);
+    const report = {
+      label: target.label,
+      commit: target.commit,
+      checkedAt: new Date().toISOString(),
+      fileCount: target.files.length,
+      successfulCount: target.files.length - result.failures.length,
+      failureCount: result.failures.length,
+      failures: result.failures,
+    };
+
+    if (args.report) {
+      writeJson(path.resolve(args.report), report);
+    }
+
+    if (result.failures.length > 0 || result.exitCode !== 0) {
+      console.error(
+        `Parsed ${target.files.length} Noir files from ${target.label} with ${result.failures.length} failures.`
+      );
+
+      for (const failure of result.failures.slice(0, 20)) {
+        console.error(
+          `- ${failure.file} (${failure.start.row}:${failure.start.column} - ${failure.end.row}:${failure.end.column})`
+        );
+      }
+
+      process.exit(1);
+    }
+
+    console.log(
+      `Parsed ${target.files.length} Noir files from ${target.label} successfully.`
+    );
+  } finally {
+    if (target?.cleanupRoot) {
+      fs.rmSync(target.cleanupRoot, { recursive: true, force: true });
+    }
+  }
+}
+
+main();

--- a/scripts/sync-upstream-noir.js
+++ b/scripts/sync-upstream-noir.js
@@ -1,0 +1,93 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  CORPUS_ROOT,
+  DEFAULT_UPSTREAM_REF,
+  DEFAULT_UPSTREAM_REPO,
+  INCLUDED_PATHS,
+  MANIFEST_PATH,
+  clearVendoredSnapshotDirs,
+  cloneUpstreamRepo,
+  collectNoirFiles,
+  getGitRevision,
+  parseArgs,
+  parseNoirFiles,
+  writeJson,
+} = require("./upstream-noir");
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  let cleanupRoot = null;
+  let sourceRoot = args.source ? path.resolve(args.source) : null;
+
+  if (!sourceRoot) {
+    cleanupRoot = cloneUpstreamRepo({
+      repoUrl: args.repo || DEFAULT_UPSTREAM_REPO,
+      ref: args.ref || DEFAULT_UPSTREAM_REF,
+    });
+    sourceRoot = cleanupRoot;
+  }
+
+  try {
+    const commit = getGitRevision(sourceRoot);
+    const candidateFiles = collectNoirFiles(sourceRoot);
+    const parseResults = parseNoirFiles(candidateFiles);
+    const successfulPaths = new Set(
+      parseResults.summaries
+        .filter((summary) => summary.successful)
+        .map((summary) => summary.file)
+    );
+    const files = candidateFiles.filter((file) =>
+      successfulPaths.has(file.absolutePath)
+    );
+
+    if (candidateFiles.length === 0) {
+      throw new Error(`No Noir files found under configured paths in ${sourceRoot}`);
+    }
+
+    if (files.length === 0) {
+      throw new Error(
+        `Collected ${candidateFiles.length} candidate Noir files from ${sourceRoot}, but none parsed successfully with the current grammar`
+      );
+    }
+
+    const perGroupCounts = {};
+    const manifestFiles = files.map((file) => {
+      perGroupCounts[file.sourceGroup] = (perGroupCounts[file.sourceGroup] || 0) + 1;
+
+      return {
+        path: file.relativePath,
+        sourceGroup: file.sourceGroup,
+      };
+    });
+
+    clearVendoredSnapshotDirs(CORPUS_ROOT);
+
+    writeJson(MANIFEST_PATH, {
+      upstream: {
+        repo: args.repo || DEFAULT_UPSTREAM_REPO,
+        ref: args.ref || DEFAULT_UPSTREAM_REF,
+        commit,
+        syncedAt: new Date().toISOString(),
+        includedPaths: INCLUDED_PATHS,
+      },
+      candidateFileCount: candidateFiles.length,
+      fileCount: manifestFiles.length,
+      excludedFailureCount: parseResults.failures.length,
+      perGroupCounts,
+      excludedFailures: parseResults.failures,
+      files: manifestFiles,
+    });
+
+    console.log(
+      `Wrote pinned upstream manifest for ${manifestFiles.length} parse-clean Noir files out of ${candidateFiles.length} candidates from ${commit} to ${MANIFEST_PATH}`
+    );
+  } finally {
+    if (cleanupRoot) {
+      fs.rmSync(cleanupRoot, { recursive: true, force: true });
+    }
+  }
+}
+
+main();

--- a/scripts/upstream-noir.js
+++ b/scripts/upstream-noir.js
@@ -1,0 +1,264 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const DEFAULT_UPSTREAM_REPO = "https://github.com/noir-lang/noir.git";
+const DEFAULT_UPSTREAM_REF = "master";
+const CORPUS_ROOT = path.join(REPO_ROOT, "test", "upstream-corpus", "noir");
+const MANIFEST_PATH = path.join(CORPUS_ROOT, "manifest.json");
+const INCLUDED_PATHS = [
+  "examples",
+  "noir_stdlib",
+  "test_programs/benchmarks",
+  "test_programs/compile_success_contract",
+  "test_programs/compile_success_empty",
+  "test_programs/compile_success_no_bug",
+  "test_programs/compile_success_with_bug",
+  "test_programs/execution_success",
+  "test_programs/noir_test_success",
+  "test_programs/test_libraries",
+];
+
+function parseArgs(argv) {
+  const args = {};
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+
+    const key = arg.slice(2);
+    const value = argv[i + 1];
+
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for --${key}`);
+    }
+
+    args[key] = value;
+    i += 1;
+  }
+
+  return args;
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...options.env },
+    stdio: options.stdio ?? "pipe",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  return result;
+}
+
+function runOrThrow(command, args, options = {}) {
+  const result = run(command, args, options);
+
+  if (result.status !== 0) {
+    const details = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
+    throw new Error(
+      details || `${command} ${args.join(" ")} exited with status ${result.status}`
+    );
+  }
+
+  return result.stdout.trim();
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function walkNoirFiles(rootDir) {
+  const files = [];
+
+  if (!fs.existsSync(rootDir)) {
+    return files;
+  }
+
+  const stack = [rootDir];
+
+  while (stack.length > 0) {
+    const currentDir = stack.pop();
+    const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const absolutePath = path.join(currentDir, entry.name);
+
+      if (entry.isDirectory()) {
+        stack.push(absolutePath);
+        continue;
+      }
+
+      if (entry.isFile() && absolutePath.endsWith(".nr")) {
+        files.push(absolutePath);
+      }
+    }
+  }
+
+  files.sort();
+  return files;
+}
+
+function collectNoirFiles(sourceRoot) {
+  const files = [];
+
+  for (const includePath of INCLUDED_PATHS) {
+    const absoluteIncludePath = path.join(sourceRoot, includePath);
+    const noirFiles = walkNoirFiles(absoluteIncludePath);
+
+    for (const absolutePath of noirFiles) {
+      files.push({
+        absolutePath,
+        relativePath: path.relative(sourceRoot, absolutePath),
+        sourceGroup: includePath,
+      });
+    }
+  }
+
+  files.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+  return files;
+}
+
+function cloneUpstreamRepo({ repoUrl = DEFAULT_UPSTREAM_REPO, ref = DEFAULT_UPSTREAM_REF }) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "tree-sitter-noir-upstream-"));
+  runOrThrow("git", ["clone", repoUrl, tempRoot]);
+  runOrThrow("git", ["-C", tempRoot, "checkout", "--detach", ref]);
+  return tempRoot;
+}
+
+function getGitRevision(repoRoot) {
+  return runOrThrow("git", ["rev-parse", "HEAD"], { cwd: repoRoot });
+}
+
+function clearVendoredSnapshotDirs(corpusRoot = CORPUS_ROOT) {
+  if (!fs.existsSync(corpusRoot)) {
+    return;
+  }
+
+  const entries = fs.readdirSync(corpusRoot, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    fs.rmSync(path.join(corpusRoot, entry.name), { recursive: true, force: true });
+  }
+}
+
+function loadManifest(manifestPath = MANIFEST_PATH) {
+  return JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+}
+
+function writeJson(filePath, value) {
+  ensureDir(path.dirname(filePath));
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function collectManifestFiles(sourceRoot, manifest) {
+  return manifest.files.map((file) => {
+    const absolutePath = path.join(sourceRoot, file.path);
+
+    if (!fs.existsSync(absolutePath)) {
+      throw new Error(`Pinned upstream file not found: ${file.path}`);
+    }
+
+    return {
+      absolutePath,
+      relativePath: file.path,
+      sourceGroup: file.sourceGroup,
+    };
+  });
+}
+
+function parseTreeSitterJson(stdout) {
+  const trimmed = stdout.trim();
+
+  if (!trimmed) {
+    throw new Error("tree-sitter parse returned empty output");
+  }
+
+  const jsonStart = trimmed.indexOf("{");
+
+  if (jsonStart === -1) {
+    throw new Error(trimmed);
+  }
+
+  return JSON.parse(trimmed.slice(jsonStart));
+}
+
+function parseNoirFiles(files) {
+  const failures = [];
+  const summaries = [];
+  let exitCode = 0;
+
+  for (const file of files) {
+    const result = run(
+      "bun",
+      ["x", "tree-sitter", "parse", "-q", "-j", file.absolutePath],
+      { cwd: REPO_ROOT }
+    );
+
+    let parsedOutput;
+
+    try {
+      parsedOutput = parseTreeSitterJson(result.stdout);
+    } catch (error) {
+      const details = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
+      throw new Error(`Could not parse tree-sitter JSON output.\n${details}`);
+    }
+
+    const summary = (parsedOutput.parse_summaries || [])[0];
+
+    if (!summary) {
+      throw new Error(`tree-sitter parse did not return a summary for ${file.absolutePath}`);
+    }
+
+    summaries.push(summary);
+
+    if (!summary.successful) {
+      failures.push({
+        file: file.relativePath,
+        start: summary.start,
+        end: summary.end,
+      });
+    }
+
+    if (result.status !== 0) {
+      exitCode = result.status;
+    }
+  }
+
+  return { exitCode, failures, summaries };
+}
+
+module.exports = {
+  CORPUS_ROOT,
+  DEFAULT_UPSTREAM_REF,
+  DEFAULT_UPSTREAM_REPO,
+  INCLUDED_PATHS,
+  MANIFEST_PATH,
+  REPO_ROOT,
+  clearVendoredSnapshotDirs,
+  cloneUpstreamRepo,
+  collectManifestFiles,
+  collectNoirFiles,
+  ensureDir,
+  getGitRevision,
+  loadManifest,
+  parseArgs,
+  parseNoirFiles,
+  parseTreeSitterJson,
+  run,
+  runOrThrow,
+  writeJson,
+};

--- a/scripts/write-upstream-canary-summary.js
+++ b/scripts/write-upstream-canary-summary.js
@@ -1,0 +1,50 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { parseArgs } = require("./upstream-noir");
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const reportPath = path.resolve(
+    args.report || "/tmp/upstream-canary-report.json"
+  );
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+
+  if (!fs.existsSync(reportPath)) {
+    console.log("::warning::Upstream canary did not produce a report.");
+    return;
+  }
+
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
+  const successRate = ((report.successfulCount / report.fileCount) * 100).toFixed(1);
+  const lines = [
+    "## Upstream Noir Canary",
+    "",
+    `- Commit: \`${report.commit}\``,
+    `- Parsed successfully: ${report.successfulCount}/${report.fileCount} (${successRate}%)`,
+    `- Failures: ${report.failureCount}`,
+  ];
+
+  if (report.failures.length > 0) {
+    lines.push("");
+    lines.push("First failures:");
+
+    for (const failure of report.failures.slice(0, 10)) {
+      lines.push(
+        `- \`${failure.file}\` (${failure.start.row}:${failure.start.column} - ${failure.end.row}:${failure.end.column})`
+      );
+    }
+
+    console.log(
+      `::warning::Upstream canary found ${report.failureCount} parse failures against ${report.commit}.`
+    );
+  }
+
+  if (summaryPath) {
+    fs.appendFileSync(summaryPath, `${lines.join("\n")}\n`);
+  } else {
+    console.log(lines.join("\n"));
+  }
+}
+
+main();

--- a/test/upstream-corpus/noir/manifest.json
+++ b/test/upstream-corpus/noir/manifest.json
@@ -1,0 +1,7567 @@
+{
+  "upstream": {
+    "repo": "https://github.com/noir-lang/noir.git",
+    "ref": "master",
+    "commit": "c49f898a3bbba67440f87acc350ff46e3ec88476",
+    "syncedAt": "2026-03-18T16:46:17.517Z",
+    "includedPaths": [
+      "examples",
+      "noir_stdlib",
+      "test_programs/benchmarks",
+      "test_programs/compile_success_contract",
+      "test_programs/compile_success_empty",
+      "test_programs/compile_success_no_bug",
+      "test_programs/compile_success_with_bug",
+      "test_programs/execution_success",
+      "test_programs/noir_test_success",
+      "test_programs/test_libraries"
+    ]
+  },
+  "candidateFileCount": 846,
+  "fileCount": 254,
+  "excludedFailureCount": 592,
+  "perGroupCounts": {
+    "examples": 5,
+    "noir_stdlib": 7,
+    "test_programs/benchmarks": 7,
+    "test_programs/compile_success_contract": 4,
+    "test_programs/compile_success_empty": 53,
+    "test_programs/compile_success_no_bug": 9,
+    "test_programs/compile_success_with_bug": 3,
+    "test_programs/execution_success": 154,
+    "test_programs/noir_test_success": 6,
+    "test_programs/test_libraries": 6
+  },
+  "excludedFailures": [
+    {
+      "file": "examples/oracle_transcript/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 63,
+        "column": 0
+      }
+    },
+    {
+      "file": "examples/profiler_cli/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 4,
+        "column": 1
+      }
+    },
+    {
+      "file": "examples/recursion/recurse_leaf/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 17,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/aes128.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/append.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 35,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/array/check_shuffle.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 186,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/array/mod.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 502,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/array/quicksort.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 299,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/cmp.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 611,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/collections/bounded_vec.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 1339,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/collections/map.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 716,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/collections/umap.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 449,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/compat.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 22,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/convert.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 300,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/default.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 147,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/embedded_curve_ops.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 205,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/field/bn254.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 203,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/field/mod.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 771,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/hash/mod.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 560,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/hash/poseidon2.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 109,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/lib.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 112,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/mem.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 31,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/meta/ctstring.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 103,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/meta/expr.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 680,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/meta/format_string.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/meta/function_def.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 96,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/meta/mod.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 312,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/meta/module.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 59,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/meta/op.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 224,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/meta/quoted.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 50,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/meta/trait_constraint.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/meta/trait_def.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 30,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/meta/trait_impl.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/meta/typ.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 221,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/meta/type_def.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 92,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/meta/typed_expr.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/meta/unresolved_type.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 40,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/ops/arith.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 971,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/ops/bit.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 373,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/option.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 232,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/panic.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 12,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/primitive_docs.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 262,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/string.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 18,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/test.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 57,
+        "column": 0
+      }
+    },
+    {
+      "file": "noir_stdlib/src/vector.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 650,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/benchmarks/bench_eddsa_poseidon/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 62,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/benchmarks/semaphore_depth_10/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 86,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_contract/contract_with_comptime_attributes/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 19,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_contract/non_entry_point_method/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/alias_trait_method_call_multiple_candidates/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 34,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/arithmetic_generics_move_constant_terms/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 29,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/arithmetic_generics/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 144,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/as_trait_path_type_expression/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 14,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/assert_constant/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 59,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/assign_evaluation_order/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 27,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/assign_mutation_in_lvalue/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 14,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/assign_to_nested_global/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 18,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/associated_constants_in_as_trait_expr/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 29,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/associated_type_bounds/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 52,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/associated_types_implicit/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 60,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/associated_types/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 28,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/attribute_args/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 21,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/attribute_order/src/a.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 13,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/attribute_order/src/a/a_child1.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 5,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/attribute_order/src/a/a_child2.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 5,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/attribute_order/src/b/b_child1.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 4,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/attribute_order/src/b/b_child2.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 2,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/attribute_order/src/b/mod.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 25,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/attribute_order/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 30,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/attribute_sees_result_of_previous_attribute/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/attributes_multiple/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/attributes_struct/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/auto_deref/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/brillig_call_from_acir_constant_input/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 20,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/brillig_cast/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 36,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/brillig_continue_break/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 22,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/brillig_vector_input/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 31,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/call_mut_closure_inside_mut_closure/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/check_large_field_bits/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 51,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/checked_transmute/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 17,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/closure_explicit_types/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 71,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_apply_range_constraint/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 5,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_array_len/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 5,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_as_primitive/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_as_vector/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_attribute_coercions/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 19,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_attribute/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 22,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_change_type_each_iteration/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 20,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_checked_transmute_success/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_closures/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 32,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_derive_generators/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 67,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_enums/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 36,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_fmtstr_with_generics/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 28,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_for_loop/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_function_definition/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 214,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_global_using_trait/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 3,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_globals_regression/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 19,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_module/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 188,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_module/src/separate_module.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 6,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_mut_global/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 28,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_negative_zero/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_parse_statement_as_expression/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 26,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_quoted/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_static_assert/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 19,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_str_as_bytes/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_struct_definition/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 69,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_to_radix/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_trait_constraint_method/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 28,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_trait_constraint/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 38,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_trait_impl/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 27,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_traits/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 33,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_type/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 173,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_typed_expr/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 6,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_u128_ops/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 19,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_unresolved_type/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_vector_equality/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 5,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/comptime_vector_methods/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 26,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/conditional_regression_to_bits/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 25,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/ctstring/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 19,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/derive_impl/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 53,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/embedded_curve_msm_simplification/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/enums/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 163,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/eq_derivation_with_numeric_generics/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/expr_has_semicolon_is_break_is_continue_consistency/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 44,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/field_or_integer_static_trait_method/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 32,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/function_attribute/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 18,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/generators/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 56,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/generic_trait_bounds/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 49,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/higher_order_fn_selector/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 30,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/impl_from_where_impl/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 18,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/impl_where_clause/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 37,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/inner_outer_cl/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/interned_crate_binary/interned_crate_library/src/lib.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 25,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/interned_crate_binary/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/lambda_call_assign_in_lambda/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/lambda_captured_variable_because_of_fmtstr/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/lambda_parameter_with_wildcard_type/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 4,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/let_stmt/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/loop_keyword/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 52,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/macros_in_comptime/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 51,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/macros/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 15,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/method_call_regression/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 30,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/nested_dereferences/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 46,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/nested_ref_param_regression_9500/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 12,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/nested_trait_associated_type_regression_8252/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 63,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/no_tuple_sharing/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 13,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/numeric_generics_explicit/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 114,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/numeric_generics/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 38,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/option/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 63,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/overlapping_dep_and_mod/bin/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/parenthesized_expression_in_array_length/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 6,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/poseidon2_simplification/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/quoted_as_type/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 21,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/quoted_struct_fields_order/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 32,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/raw_string/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 13,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/references_aliasing/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 272,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_10445/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 18,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_10521/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 3,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_10813/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 17,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_10874/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 14,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_10907/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 13,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_11325/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 5,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_3635/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 6,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_4383/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 3,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_4436/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 31,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_4635/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 61,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_5065/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 48,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_5428/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_5462/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_5671/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 20,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_5823/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 5,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_6383_1/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 22,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_6383_2/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 22,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_7038_2/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 39,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_7038_3/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 40,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_7038_4/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 29,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_7038/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 40,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_7570_nested/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 30,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_7570_serial/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 27,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_7749/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_7785/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 14,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_9245/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 39,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_9248/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 49,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_9398/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 13,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_9729/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 3,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/regression_bignum/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 53,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/resolved_type_in_constructor/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/ret_fn_ret_cl/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 31,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/serialize_1/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 64,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/serialize_2/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 27,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/serialize_3/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 42,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/serialize_4/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 64,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/serialize_5/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 53,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/static_assert/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 46,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/to_bits/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 21,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_as_constraint/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_as_type_associated_type_not_lost/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_attribute/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 19,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_call_full_path/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 20,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_default_implementation/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_default_method_uses_op/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_function_calls/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 786,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_generics/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 69,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_impl_generics/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 67,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_impl_with_where_clause/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 30,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_inheritance/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 33,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_inheritence_call_method_on_self/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_method_mut_self/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 83,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_multi_module_test/src/module1.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 1,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_multi_module_test/src/module4.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 1,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_override_implementation/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 82,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_static_methods/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 64,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_where_clause/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 86,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/trait_where_clause/src/the_trait.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/traits/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 19,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/turbofish_call_func_diff_types/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 37,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/type_path/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 39,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/type_trait_method_call_multiple_candidates_with_turbofish/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 25,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/type_trait_method_call_multiple_candidates/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 32,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/unquote_function/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 12,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/unquote_in_numeric_generic/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 28,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/unquote_multiple_items_from_annotation/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 14,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/unquote_struct/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 38,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/unquote_trait_constraint_in_trait_impl_position/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/unquote/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 4,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/use_callers_scope/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 30,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/vector_init_with_complex_type/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 17,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/vector_join/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 19,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_empty/while_keyword/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 44,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/check_unconstrained_regression/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 34,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/databus_mapping_regression/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 48,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/function_registry/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 52,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/inline_diverging_function/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 15,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/post_order_for_unreachable_blocks/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 17,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/ram_blowup_regression/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 41,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_10298/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 31,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_10631/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 74,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_10689/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 28,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_10748/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 38,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_11146/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 14,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_11147/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 39,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_11309/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 12,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_11490/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 18,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_11599/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_11827/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 20,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_7062/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_7103/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 15,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_8081/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_8199/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 6,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_8665/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 27,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_8727/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_9006/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 12,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_9165/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_9207/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 14,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_9284/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 6,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_9461/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_9695/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 25,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/regression_9997/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_no_bug/unconditional_break/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 95,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_with_bug/regression_10117/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_with_bug/regression_10498/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_with_bug/regression_8774/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 4,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_with_bug/regression_8995/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_with_bug/regression_9872/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 4,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/compile_success_with_bug/underconstrained_value_detector_5425/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 49,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/a_1_mul/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/a_2_div/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/a_3_add/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/a_6_array/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 54,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/a_6/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/a_7_function/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 139,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/aes128_encrypt/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 39,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/array_dedup_regression/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 21,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/array_dynamic_blackbox_input/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 27,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/array_dynamic_nested_blackbox_input/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 20,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/array_dynamic/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 38,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/array_len/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 24,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/array_of_references_in_loop/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/array_oob_regression_7965/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/array_oob_regression_7975/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/array_rc_regression_7842/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/array_set_not_deduplicated/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 21,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/array_to_vector_constant_length/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 12,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/array_to_vector/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 56,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/array_with_refs_from_param/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/array_with_refs_return/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/as_str_unchecked_with_broken_bytes/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/assert_statement/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/assert/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/assign_ex/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 14,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/binary_operator_overloading/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 150,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/bit_shifts_comptime/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 39,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/bit_shifts_runtime/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 29,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/bit_shifts_u128/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_array_ifelse/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 30,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_arrays/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 31,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_block_parameter_liveness/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 90,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_calls_array/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 36,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_calls_conditionals/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 38,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_cow_regression/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 177,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_cow/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 48,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_entry_points_regression_8069/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 28,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_fns_as_values/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 37,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_identity_function/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 35,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_large_array/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 133,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_large_nested_array/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 184,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_loop_size_regression/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 17,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_nested_arrays/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 43,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_pedersen/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 26,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_rc_regression_6123/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 41,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/brillig_recursive_main_indirect/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 15,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/closures_mut_ref/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 26,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/comptime_closure_bindings_1/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 21,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/comptime_closure_bindings_2/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 22,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/comptime_generics_binding/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 35,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/comptime_println_fmtstr_with_quoted/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/comptime_println/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 19,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/comptime_quoted_hash/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 35,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/comptime_trait_constraint_hash_and_eq/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 80,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/comptime_variable_at_runtime/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/conditional_1/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 91,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/conditional_regression_421/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/conditional_regression_661/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 27,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/conditional_regression_short_circuit/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 36,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/conditional_vector_insert_at_end_of_vector/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 14,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/databus_composite_calldata/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/databus_two_calldata_simple/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 5,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/databus_two_calldata/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 15,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/databus/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/debug_logs/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 142,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/derive/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 81,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/do_not_capture_comptime_locals/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 5,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/double_neg_cond_global_var/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 22,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/dual_constrained_lambdas/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 32,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/embedded_curve_ops/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 94,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/empty_strings_in_composite_arrays/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/encrypted_log_regression/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 94,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/fmtstr_with_global/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 5,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/fold_complex_outputs/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 71,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/fold_numeric_generic_poseidon/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 31,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/for_loop_inclusive_empty_range/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/for_loop_inclusive_u8_max/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/for_loop_inclusive_with_break/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/generics/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 82,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/global_consts/src/baz.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 5,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/global_consts/src/foo.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/global_consts/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 119,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/global_nested_array_call_arg_regression/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 15,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/global_nested_array_regression_9270/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/global_var_regression_entry_points/src/consts.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 3842,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/global_var_regression_simple/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 25,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/global_vector_rc_regression_8259/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/hashmap/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 380,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/hashmap/src/utils.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/higher_order_functions/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 94,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/hint_black_box/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 91,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/if_else_chain/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 14,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/inline_decompose_hint_brillig_call/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 18,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/inline_never_basic/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/integer_array_indexing/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/lambda_env_is_copied/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 12,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/lambda_from_array/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 66,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/lambda_from_dynamic_if/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 31,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/lambda_from_global_array/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 13,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/lambda_from_global_tuple/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 14,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/lambda_taking_lambda_regression_8543/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/lambda_taking_lambda_with_variant/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 17,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/loop_break_regression_8319/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 42,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/loop_carried_aliases/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 58,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/loop_invariant_nested_deep/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 50,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/loop_invariant_regression_8586/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/loop/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 53,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/merkle_insert/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 28,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/missing_closure_env/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/modulus/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 34,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/multi_scalar_mul/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 53,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/mutate_array_copy/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/negative_associated_constants/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 22,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/nested_array_call_arg_regression/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 15,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/nested_array_dynamic_simple/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/nested_array_dynamic/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 75,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/nested_array_in_vector/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 49,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/nested_array_with_refs_from_param/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/nested_array_with_refs_return/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/nested_array_with_refs/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/nested_arrays_from_brillig/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 26,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/nested_dyn_array_regression_5782/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 13,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/nested_fmtstr/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 13,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/nested_vector_last_index_access_post_insert/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 12,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/nested_vector_pop_back/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/nested_vector_pop_front_return/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/nested_vector_push_front_return/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/nested_vector_return/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/no_predicates_numeric_generic_poseidon/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 33,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/numeric_type_alias/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 129,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/overlapping_dep_and_mod/bin/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 14,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/pedersen_check/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 19,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/poseidonsponge_x5_254/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/print_composite_array/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 4,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/reference_alias_in_array/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 19,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/reference_cancelling/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/reference_counts_inliner_0/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 131,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/reference_counts_inliner_max/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 127,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/reference_counts_inliner_min/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 131,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/reference_counts_vectors_inliner_0/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 137,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/reference_only_used_as_alias/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 92,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/references/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 309,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10141/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10156/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 42,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10158/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10170/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 40,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10180/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 13,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10197/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 5,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10198/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10307/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 6,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10446/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10452/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 21,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10466/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 31,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10516/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 15,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10690/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 4,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10917/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 29,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10923/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 19,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_10975/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 37,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_11048/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 12,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_11134/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 30,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_11294/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 186,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_11402/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_1144_1169_2399_6609/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 141,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_11440/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_11463/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 35,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_11484/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 13,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_11540/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 30,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_11659/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 50,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_3051/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 24,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_4088/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 30,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_4124/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 42,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_4202/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 14,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_4449/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 12,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_4663/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_4709/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 3854,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_5045/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 20,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_5252/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_5435/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_5615/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 12,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_6285/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_6451/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 24,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_6674_1/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 85,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_6674_2/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 87,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_6674_3/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 194,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_6734/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 24,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_6834/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_6990/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_7062/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_7128/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 26,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_7143/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 3,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_7195/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 21,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_7323/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_7451/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 12,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_7612/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_8174/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 4,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_8236/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_8261/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_8662/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 22,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_8729/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 19,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_8739/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 15,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_8755/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 14,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_8761/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_8779/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 4,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_8874/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_8926/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_8975/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 21,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_8980/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 15,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9037/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 28,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9047/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9102/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 17,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9116/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 66,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9116/src/meta.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 95,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9119/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9160/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 21,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9193/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 3,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9206/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9208/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9243/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9271/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 20,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9294/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9303/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 17,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9312/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9329/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9415/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9439/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9455/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 6,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9467/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9496/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 61,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9538/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9546/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 13,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9578/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 33,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9593/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9594/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9657/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 14,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9725_2/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 15,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9758/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9764/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9804/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 12,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9860/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9888/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 15,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_9907/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 19,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_brillig_const_fold_self_dedup/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 43,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_brillig_ref_deref_crash/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 22,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_mem2reg_unknown_array_aliases/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 28,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_struct_array_conditional/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 38,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_truncate_unchecked_sub/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 3,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_unsafe_no_predicates/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 24,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/regression_unused_nested_array_get/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 17,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/return_twice/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 5,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/shl_signed_regression_9661/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 11,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/side_effects_constrain_array/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 17,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/signed_bitshift/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 10,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/signed_division/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 22,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/signed_truncation/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 6,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/simple_2d_array/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/simple_add_and_ret_arr/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/simple_shield/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 41,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/static_assert_empty_loop/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 81,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/strings/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 84,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/struct_assignment_with_shared_ref_to_field/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 22,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/struct_inputs/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 34,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/struct/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 75,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/to_be_bytes/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 13,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/to_bytes_integration/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/to_le_bytes/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 13,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/trait_as_return_type/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 51,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/trait_associated_constant/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 25,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/trait_impl_base_type/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 115,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/traits_in_crates_1/crate1/src/lib.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/traits_in_crates_1/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/traits_in_crates_2/crate1/src/lib.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 3,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/traits_in_crates_2/crate2/src/lib.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/traits_in_crates_2/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 7,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/tuple_inputs/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 35,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/tuples/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 22,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/type_aliases/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 33,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/uhashmap/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 351,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/unary_operator_overloading/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 36,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/unroll_loop_regression/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 25,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/unrolling_regression_8333/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/unsafe_range_constraint/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 5,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/vector_coercion/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 27,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/vector_dynamic_index/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 307,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/vector_dynamic_insert/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 31,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/vector_insert_empty_oob/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/vector_loop/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 32,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/vector_pop_back_simplify/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/vector_push_back_remove_if_else_bug/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/vector_regex/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 807,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/vectors/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 376,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/while_loop_break_regression_8521/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 16,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/execution_success/wildcard_type/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/assert_message/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 15,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/bit_shifts/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 139,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/bounded_vec/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 259,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/brillig_oracle/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 53,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/brillig_overflow_checks/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 20,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/comptime_blackbox/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 150,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/comptime_expr/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 782,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/comptime_globals/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 25,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/embedded_curve_ops/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 33,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/field_comparisons/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 18,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/fuzzer_checks/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/global_and_local_array_sort/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 47,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/global_eval/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/ignored_oracle/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/mock_oracle/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 290,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/oracle_return_vector/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 41,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/oracle_returning_composite_array/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 29,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/out_of_bounds_alignment/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 23,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/regression_4080/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 8,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/regression_4561/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 90,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/regression_9174/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 45,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/regression_9335/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 12,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/regression_noir_sort/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 46,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/regression_noir_sort/src/quicksort.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 61,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/should_fail_with_matches/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 93,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/signed_double_negation/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 34,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/ski_calculus_test_add_and_show/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 48,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/ski_calculus_test_identity_and_show/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 32,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/ski_calculus_test_logic_and_show/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 36,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/ski_calculus_test_numeric_and_show/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 39,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/ski_calculus_test_pow_and_show/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 45,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/noir_test_success/to_radix_error/src/main.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 29,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/test_libraries/exporting_lib/src/lib.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 9,
+        "column": 0
+      }
+    },
+    {
+      "file": "test_programs/test_libraries/ski_calculus_lib/src/lib.nr",
+      "start": {
+        "row": 0,
+        "column": 0
+      },
+      "end": {
+        "row": 678,
+        "column": 0
+      }
+    }
+  ],
+  "files": [
+    {
+      "path": "examples/browser/src/main.nr",
+      "sourceGroup": "examples"
+    },
+    {
+      "path": "examples/prove_and_verify/src/main.nr",
+      "sourceGroup": "examples"
+    },
+    {
+      "path": "examples/recursion/recurse_node/src/main.nr",
+      "sourceGroup": "examples"
+    },
+    {
+      "path": "examples/recursion/sum/src/main.nr",
+      "sourceGroup": "examples"
+    },
+    {
+      "path": "examples/solidity_verifier/src/main.nr",
+      "sourceGroup": "examples"
+    },
+    {
+      "path": "noir_stdlib/src/collections/mod.nr",
+      "sourceGroup": "noir_stdlib"
+    },
+    {
+      "path": "noir_stdlib/src/ecdsa_secp256k1.nr",
+      "sourceGroup": "noir_stdlib"
+    },
+    {
+      "path": "noir_stdlib/src/ecdsa_secp256r1.nr",
+      "sourceGroup": "noir_stdlib"
+    },
+    {
+      "path": "noir_stdlib/src/hint.nr",
+      "sourceGroup": "noir_stdlib"
+    },
+    {
+      "path": "noir_stdlib/src/ops/mod.nr",
+      "sourceGroup": "noir_stdlib"
+    },
+    {
+      "path": "noir_stdlib/src/prelude.nr",
+      "sourceGroup": "noir_stdlib"
+    },
+    {
+      "path": "noir_stdlib/src/runtime.nr",
+      "sourceGroup": "noir_stdlib"
+    },
+    {
+      "path": "test_programs/benchmarks/bench_poseidon_hash_100/src/main.nr",
+      "sourceGroup": "test_programs/benchmarks"
+    },
+    {
+      "path": "test_programs/benchmarks/bench_poseidon_hash_30/src/main.nr",
+      "sourceGroup": "test_programs/benchmarks"
+    },
+    {
+      "path": "test_programs/benchmarks/bench_poseidon_hash/src/main.nr",
+      "sourceGroup": "test_programs/benchmarks"
+    },
+    {
+      "path": "test_programs/benchmarks/bench_poseidon2_hash_100/src/main.nr",
+      "sourceGroup": "test_programs/benchmarks"
+    },
+    {
+      "path": "test_programs/benchmarks/bench_poseidon2_hash_30/src/main.nr",
+      "sourceGroup": "test_programs/benchmarks"
+    },
+    {
+      "path": "test_programs/benchmarks/bench_poseidon2_hash/src/main.nr",
+      "sourceGroup": "test_programs/benchmarks"
+    },
+    {
+      "path": "test_programs/benchmarks/sha512_100_bytes/src/main.nr",
+      "sourceGroup": "test_programs/benchmarks"
+    },
+    {
+      "path": "test_programs/compile_success_contract/abi_attribute/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_contract"
+    },
+    {
+      "path": "test_programs/compile_success_contract/contract_with_impl/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_contract"
+    },
+    {
+      "path": "test_programs/compile_success_contract/fold_non_contract_method/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_contract"
+    },
+    {
+      "path": "test_programs/compile_success_contract/simple_contract/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_contract"
+    },
+    {
+      "path": "test_programs/compile_success_empty/acir_inside_brillig_recursion/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/brillig_field_binary_operations/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/brillig_integer_binary_operations/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/brillig_modulo/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/cast_and_shift_global/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/comptime_recursion_regression/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/conditional_regression_579/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/embedded_curve_add_simplification/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/empty/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/instruction_deduplication/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/interned_crate_binary/interned_crate_library/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/is_unconstrained/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/literal_not_simplification/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/loop_over_u1_range/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/mod_nr_entrypoint/src/baz.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/mod_nr_entrypoint/src/foo/bar.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/mod_nr_entrypoint/src/foo/mod.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/mod_nr_entrypoint/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/nargo_expand_references/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/no_duplicate_methods/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/overlapping_dep_and_mod/foo/src/lib.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/primitive_trait_method_call_multiple_candidates/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/reexports/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/regression_11207/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/regression_11578/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/regression_11582/aztec/src/lib.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/regression_11582/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/regression_2099/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/regression_3964/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/regression_5489/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/regression_7433/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/signed_lower_loop_bound_regression_8858/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/simple_program_no_body/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/simple_range/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/specialization/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/str_as_bytes/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/struct_public_field/dependency/src/lib.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/struct_public_field/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/trait_associated_member_names_clashes/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/trait_call_in_global/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/trait_multi_module_test/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/trait_multi_module_test/src/module2.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/trait_multi_module_test/src/module3.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/trait_multi_module_test/src/module5.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/trait_multi_module_test/src/module6.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/unary_operators/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/unit_value/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/unit/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/unused_variables/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/workspace_reexport_bug/binary/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/workspace_reexport_bug/library/src/lib.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/workspace_reexport_bug/library2/src/lib.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_empty/zeroed_vector/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_empty"
+    },
+    {
+      "path": "test_programs/compile_success_no_bug/noirc_evaluator_ssa_ssa_gen_tests_assert_eq/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_no_bug"
+    },
+    {
+      "path": "test_programs/compile_success_no_bug/noirc_evaluator_ssa_ssa_gen_tests_assert/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_no_bug"
+    },
+    {
+      "path": "test_programs/compile_success_no_bug/noirc_evaluator_ssa_ssa_gen_tests_basic_loop/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_no_bug"
+    },
+    {
+      "path": "test_programs/compile_success_no_bug/regression_10136/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_no_bug"
+    },
+    {
+      "path": "test_programs/compile_success_no_bug/regression_10153/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_no_bug"
+    },
+    {
+      "path": "test_programs/compile_success_no_bug/regression_10817/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_no_bug"
+    },
+    {
+      "path": "test_programs/compile_success_no_bug/regression_10887/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_no_bug"
+    },
+    {
+      "path": "test_programs/compile_success_no_bug/regression_7292/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_no_bug"
+    },
+    {
+      "path": "test_programs/compile_success_no_bug/regression_9067/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_no_bug"
+    },
+    {
+      "path": "test_programs/compile_success_with_bug/empty_vector_set/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_with_bug"
+    },
+    {
+      "path": "test_programs/compile_success_with_bug/regression_8272/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_with_bug"
+    },
+    {
+      "path": "test_programs/compile_success_with_bug/regression_8274/src/main.nr",
+      "sourceGroup": "test_programs/compile_success_with_bug"
+    },
+    {
+      "path": "test_programs/execution_success/a_1327_concrete_in_generic/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/a_4_sub/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/a_5_over/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/a_7/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/arithmetic_binary_operations/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/array_dynamic_main_output/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/array_eq/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/array_if_cond_simple/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/array_neq/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/array_sort/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/as_witness/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/bench_2_to_17/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/bench_ecdsa_secp256k1/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/bit_and/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/bit_not/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/blake3/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/bool_not/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/bool_or/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/break_and_continue/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/brillig_acir_as_brillig/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/brillig_blake2s/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/brillig_calls/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/brillig_conditional/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/brillig_constant_reference_regression/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/brillig_cow_assign/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/brillig_not/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/brillig_recursion/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/brillig_recursive_main/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/brillig_uninitialized_arrays/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/cast_bool/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/cast_signed_to_u1/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/cast_to_i8_regression_7776/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/cast_to_u128/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/cast_to_u64_regression_7776/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/cast_to_u8_regression_7776/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/conditional_2/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/conditional_regression_547/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/conditional_regression_underflow/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/custom_entry/src/foobarbaz.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/diamond_deps_0/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/division_by_max/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/dont_deduplicate_call/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/double_neg_cond_bool_input/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/ecdsa_secp256k1_invalid_inputs/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/ecdsa_secp256k1_invalid_pub_key_in_inactive_branch/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/ecdsa_secp256k1/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/ecdsa_secp256r1_3x/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/ecdsa_secp256r1_invalid_pub_key_in_inactive_branch/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/ecdsa_secp256r1_msg_equals_order/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/ecdsa_secp256r1/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/field_attribute/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/fold_2_to_17/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/fold_after_inlined_calls/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/fold_basic_nested_call/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/fold_basic/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/fold_call_witness_condition/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/fold_distinct_return/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/fold_fibonacci/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/function_ref/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/global_array_rc_regression_8259/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/global_consts/src/foo/bar.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/global_var_entry_point_used_in_another_entry/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/global_var_func_with_multiple_entry_points/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/global_var_multiple_entry_points_nested/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/global_var_regression_entry_points/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/import/src/import.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/import/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/inactive_signed_bitshift/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/last_uses_regression_8935/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/loop_invariant_regression/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/loop_small_break/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/main_bool_arg/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/main_return/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/modules_more/src/foo.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/modules_more/src/foo/bar.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/modules_more/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/modules/src/foo.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/modules/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/negated_jmpif_condition/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/nested_if_then_block_same_cond/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/no_predicates_basic/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/no_predicates_brillig/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/overlapping_dep_and_mod/foo/src/lib.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/pedersen_commitment/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/pedersen_hash/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/poseidon_bn254_hash_width_3/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/pred_eq/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_10008/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_10977/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_2660/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_3394/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_3607/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_3889/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_7744/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_7836/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_7962/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_8009/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_8011/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_8212/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_8235/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_8305/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_8329/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_8519/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_8558/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_8726/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_8890/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_9541/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_9544/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_9725_1/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_9971/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_capacity_tracker/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_licm_induction_var/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_mem_op_predicate/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/regression_method_cannot_be_found/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/shift_left_rhs_value_casted_from_smaller_type/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/shift_right_overflow/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/signed_arithmetic/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/signed_cmp/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/signed_comparison/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/signed_div/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/signed_inactive_division_by_zero/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/signed_overflow_in_else_regression_8617/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/simple_array_param/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/simple_bitwise/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/simple_comparison/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/simple_mut/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/simple_not/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/simple_print/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/simple_program_addition/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/simple_radix/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/simple_shift_left_right/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/struct_array_inputs/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/struct_fields_ordering/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/struct_inputs/src/foo.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/struct_inputs/src/foo/bar.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/submodules/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/to_bytes_consistent/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/traits_in_crates_1/crate2/src/lib.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/u128_type/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/u16_support/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/unsigned_to_signed_cast/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/vector_insert_oob_invalid_pred/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/vector_insert_oob/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/vector_pop_back_oob_invalid_pred/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/vector_pop_front_oob_invalid_pred/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/vector_remove_oob_invalid_pred/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/while_cond_clone_regression/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/witness_compression/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/workspace_default_member/a/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/workspace_default_member/b/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/workspace/crates/a/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/workspace/crates/b/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/wrapping_operations/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/execution_success/xor/src/main.nr",
+      "sourceGroup": "test_programs/execution_success"
+    },
+    {
+      "path": "test_programs/noir_test_success/ski_calculus_test_add/src/main.nr",
+      "sourceGroup": "test_programs/noir_test_success"
+    },
+    {
+      "path": "test_programs/noir_test_success/ski_calculus_test_identity/src/main.nr",
+      "sourceGroup": "test_programs/noir_test_success"
+    },
+    {
+      "path": "test_programs/noir_test_success/ski_calculus_test_logic/src/main.nr",
+      "sourceGroup": "test_programs/noir_test_success"
+    },
+    {
+      "path": "test_programs/noir_test_success/ski_calculus_test_numeric/src/main.nr",
+      "sourceGroup": "test_programs/noir_test_success"
+    },
+    {
+      "path": "test_programs/noir_test_success/ski_calculus_test_pow/src/main.nr",
+      "sourceGroup": "test_programs/noir_test_success"
+    },
+    {
+      "path": "test_programs/noir_test_success/u128_type/src/main.nr",
+      "sourceGroup": "test_programs/noir_test_success"
+    },
+    {
+      "path": "test_programs/test_libraries/bad_impl/src/lib.nr",
+      "sourceGroup": "test_programs/test_libraries"
+    },
+    {
+      "path": "test_programs/test_libraries/bad_name/src/lib.nr",
+      "sourceGroup": "test_programs/test_libraries"
+    },
+    {
+      "path": "test_programs/test_libraries/bin_dep/src/main.nr",
+      "sourceGroup": "test_programs/test_libraries"
+    },
+    {
+      "path": "test_programs/test_libraries/diamond_deps_1/src/lib.nr",
+      "sourceGroup": "test_programs/test_libraries"
+    },
+    {
+      "path": "test_programs/test_libraries/diamond_deps_2/src/lib.nr",
+      "sourceGroup": "test_programs/test_libraries"
+    },
+    {
+      "path": "test_programs/test_libraries/reexporting_lib/src/lib.nr",
+      "sourceGroup": "test_programs/test_libraries"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add scripts to sync a pinned upstream Noir manifest and verify it by downloading the pinned commit in CI
- add a scheduled informational canary workflow for the full live upstream corpus
- document the contributor workflow in CONTRIBUTING.md and link it from the README

## Testing
- bun run test
- bun run test:upstream-corpus
- node scripts/check-upstream-corpus.js --source /tmp/tree-sitter-noir-upstream --label upstream-master --report /tmp/upstream-canary-report.json