### PR TITLE
ci: add Codex upstream canary autofix

### DIFF
--- a/.github/codex/prompts/upstream-canary-autofix.md
+++ b/.github/codex/prompts/upstream-canary-autofix.md
@@ -1,0 +1,21 @@
+# Upstream Canary Auto-Fix
+
+You are fixing `tree-sitter-noir` after a failed upstream canary run.
+
+Start by reading:
+
+- `tmp/codex/upstream-canary-context.md`
+- `tmp/canary-artifact/upstream-canary-report.json`
+
+The workflow has already checked out the matching upstream Noir commit into
+`tmp/upstream-noir`.
+
+Requirements:
+
+1. Reproduce the failure with `bun scripts/check-upstream-corpus.js --source tmp/upstream-noir --label upstream-canary --report tmp/canary-artifact/upstream-canary-report.json`.
+2. Make the smallest repository changes needed so both `bun run test` and the upstream canary reproduction pass.
+3. Add or update focused corpus tests for any grammar changes.
+4. Do not edit files under `tmp/` except to regenerate the canary report during verification.
+5. Do not update dependencies, workflow files, or the pinned upstream manifest unless they are directly required for the parser fix.
+
+Stop once the parser fix is in place and both verification commands succeed.

--- a/.github/workflows/upstream-canary-autofix.yml
+++ b/.github/workflows/upstream-canary-autofix.yml
@@ -1,0 +1,158 @@
+name: upstream-canary-autofix
+on:
+  workflow_run:
+    workflows:
+      - upstream-canary
+    types:
+      - completed
+
+jobs:
+  autofix:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    env:
+      FAILED_RUN_ID: ${{ github.event.workflow_run.id }}
+      FAILED_RUN_URL: ${{ github.event.workflow_run.html_url }}
+      FAILED_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      FAILED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Check OpenAI API key
+        run: |
+          if [ -z "${{ secrets.OPENAI_API_KEY }}" ]; then
+            echo "OPENAI_API_KEY is not configured for upstream-canary-autofix." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.FAILED_HEAD_BRANCH }}
+          fetch-depth: 0
+
+      - name: Reset checkout to failed revision
+        run: git reset --hard "$FAILED_HEAD_SHA"
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.6
+
+      - run: bun install --frozen-lockfile
+
+      - name: Resolve canary artifact
+        id: artifact
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: Number(process.env.FAILED_RUN_ID),
+                per_page: 100,
+              }
+            );
+            const artifact = artifacts.find(
+              (entry) => entry.name === "upstream-noir-canary-report"
+            );
+
+            if (!artifact) {
+              core.setFailed(
+                `Could not find upstream-noir-canary-report for run ${process.env.FAILED_RUN_ID}.`
+              );
+              return;
+            }
+
+            core.setOutput("artifact-id", String(artifact.id));
+
+      - name: Download canary report
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p tmp/canary-artifact
+          curl --fail --location \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${{ steps.artifact.outputs.artifact-id }}/zip" \
+            --output tmp/canary-artifact/upstream-noir-canary-report.zip
+          unzip -o tmp/canary-artifact/upstream-noir-canary-report.zip -d tmp/canary-artifact
+          test -f tmp/canary-artifact/upstream-canary-report.json
+
+      - name: Read canary report metadata
+        id: report
+        run: |
+          upstream_commit="$(node -p "JSON.parse(require('node:fs').readFileSync('tmp/canary-artifact/upstream-canary-report.json', 'utf8')).commit")"
+          failure_count="$(node -p "JSON.parse(require('node:fs').readFileSync('tmp/canary-artifact/upstream-canary-report.json', 'utf8')).failureCount")"
+          echo "upstream-commit=${upstream_commit}" >> "$GITHUB_OUTPUT"
+          echo "failure-count=${failure_count}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout matching upstream Noir commit
+        run: |
+          git init tmp/upstream-noir
+          git -C tmp/upstream-noir remote add origin https://github.com/noir-lang/noir.git
+          git -C tmp/upstream-noir fetch --depth 1 origin "${{ steps.report.outputs.upstream-commit }}"
+          git -C tmp/upstream-noir checkout --detach FETCH_HEAD
+
+      - name: Write Codex context
+        run: |
+          mkdir -p tmp/codex
+          cat <<'EOF' > tmp/codex/upstream-canary-context.md
+          # Upstream Canary Context
+
+          - Failed workflow run: ${{ env.FAILED_RUN_URL }}
+          - Base branch: `${{ env.FAILED_HEAD_BRANCH }}`
+          - Base commit: `${{ env.FAILED_HEAD_SHA }}`
+          - Upstream Noir commit: `${{ steps.report.outputs.upstream-commit }}`
+          - Reported parse failures: `${{ steps.report.outputs.failure-count }}`
+          - Report JSON: `tmp/canary-artifact/upstream-canary-report.json`
+          - Upstream checkout: `tmp/upstream-noir`
+          EOF
+
+      - name: Run Codex
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt-file: .github/codex/prompts/upstream-canary-autofix.md
+          output-file: tmp/codex-output.md
+          safety-strategy: drop-sudo
+          sandbox: workspace-write
+          codex-args: '["--full-auto"]'
+
+      - name: Verify parser tests
+        run: bun run test
+
+      - name: Verify upstream canary reproduction
+        run: bun scripts/check-upstream-corpus.js --source tmp/upstream-noir --label upstream-${{ steps.report.outputs.upstream-commit }} --report tmp/canary-artifact/upstream-canary-report.json
+
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upstream-canary-codex-output
+          path: tmp/codex-output.md
+          if-no-files-found: ignore
+
+      - name: Create pull request
+        id: create_pr
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: codex/upstream-canary-${{ env.FAILED_RUN_ID }}
+          base: ${{ env.FAILED_HEAD_BRANCH }}
+          commit-message: |
+            fix: address upstream Noir canary failures
+
+            Generated from failed upstream-canary run ${{ env.FAILED_RUN_URL }}.
+          title: "fix: address upstream Noir canary failures"
+          body: |
+            This PR was generated automatically by `upstream-canary-autofix`.
+
+            - Failed canary run: ${{ env.FAILED_RUN_URL }}
+            - Base branch: `${{ env.FAILED_HEAD_BRANCH }}`
+            - Base commit: `${{ env.FAILED_HEAD_SHA }}`
+            - Upstream Noir commit: `${{ steps.report.outputs.upstream-commit }}`
+            - Reported parse failures: `${{ steps.report.outputs.failure-count }}`
+
+            The workflow downloaded the canary report artifact, checked out the matching upstream Noir commit, ran Codex to apply the smallest parser fix, and re-ran both `bun run test` and the upstream canary reproduction before opening this PR.

--- a/.github/workflows/upstream-canary-autofix.yml
+++ b/.github/workflows/upstream-canary-autofix.yml
@@ -85,8 +85,8 @@ jobs:
       - name: Read canary report metadata
         id: report
         run: |
-          upstream_commit="$(node -p "JSON.parse(require('node:fs').readFileSync('tmp/canary-artifact/upstream-canary-report.json', 'utf8')).commit")"
-          failure_count="$(node -p "JSON.parse(require('node:fs').readFileSync('tmp/canary-artifact/upstream-canary-report.json', 'utf8')).failureCount")"
+          upstream_commit="$(bun -e "const report = await Bun.file('tmp/canary-artifact/upstream-canary-report.json').json(); console.log(report.commit)")"
+          failure_count="$(bun -e "const report = await Bun.file('tmp/canary-artifact/upstream-canary-report.json').json(); console.log(report.failureCount)")"
           echo "upstream-commit=${upstream_commit}" >> "$GITHUB_OUTPUT"
           echo "failure-count=${failure_count}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/upstream-canary.yml
+++ b/.github/workflows/upstream-canary.yml
@@ -13,15 +13,17 @@ jobs:
         with:
           bun-version: 1.3.6
       - run: bun install --frozen-lockfile
-      - run: git clone --depth 1 https://github.com/noir-lang/noir.git /tmp/tree-sitter-noir-upstream
+      - run: git clone --depth 1 https://github.com/noir-lang/noir.git tmp/upstream-noir
       - id: canary
         continue-on-error: true
-        run: bun scripts/check-upstream-corpus.js --source /tmp/tree-sitter-noir-upstream --label upstream-master --report /tmp/upstream-canary-report.json
+        run: bun scripts/check-upstream-corpus.js --source tmp/upstream-noir --label upstream-master --report tmp/upstream-canary-report.json
       - if: always()
-        run: bun scripts/write-upstream-canary-summary.js --report /tmp/upstream-canary-report.json
+        run: bun scripts/write-upstream-canary-summary.js --report tmp/upstream-canary-report.json
       - if: always()
         uses: actions/upload-artifact@v4
         with:
           name: upstream-noir-canary-report
-          path: /tmp/upstream-canary-report.json
+          path: tmp/upstream-canary-report.json
           if-no-files-found: ignore
+      - if: always()
+        run: bun scripts/fail-upstream-canary.js --report tmp/upstream-canary-report.json --canary-outcome ${{ steps.canary.outcome }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,9 +77,15 @@ Pull requests are expected to pass:
 - `bun run test`
 - `bun run test:upstream-corpus`
 
-The scheduled `upstream-canary` workflow is informational. It checks the full
-current upstream Noir corpus, uploads a JSON report artifact, and writes a job
-summary so parser drift stays visible without breaking required CI.
+The scheduled `upstream-canary` workflow checks the full current upstream Noir
+corpus, uploads a JSON report artifact, writes a job summary, and now fails if
+the parser regresses against upstream.
+
+When `upstream-canary` fails with a report artifact present, the
+`upstream-canary-autofix` workflow downloads that report, checks out the exact
+upstream Noir commit, runs Codex to attempt a minimal fix, and opens a pull
+request if verification passes. This automation requires an `OPENAI_API_KEY`
+repository secret and GitHub Actions permission to create pull requests.
 
 The pinned upstream-corpus check downloads the upstream Noir repository at the
 commit recorded in the manifest, builds the current parser locally, and then

--- a/README.md
+++ b/README.md
@@ -5,15 +5,14 @@
 [![Latest version](https://img.shields.io/crates/v/tree-sitter-noir.svg)](https://crates.io/crates/tree-sitter-noir)
 ![gpl-3.0](https://shields.io/badge/gpl-3.0-blue)
 
-
 Noir grammar and parser for [tree-sitter](https://tree-sitter.github.io/tree-sitter/)
 
-
 ### Emacs
+
 To use with Emacs; use the following [package here](https://github.com/hhamud/noir-ts-mode).
 
-
 ### NeoVim
+
 To use this parser with current `nvim-treesitter`, register the custom parser in
 the `User TSUpdate` hook, make sure Neovim recognizes `.nr` files as `noir`,
 and start tree-sitter highlighting for that filetype:
@@ -57,12 +56,13 @@ directory manually.
 ## Other
 
 To install the grammar from NPM
+
 ```shell
 npm i tree-sitter-noir
 ```
 
-
 To install the grammar from cargo
+
 ```shell
 cargo add tree-sitter-noir
 ```
@@ -101,9 +101,12 @@ This repository now tracks upstream in two ways:
   against that commit. Required CI downloads that pinned upstream revision and
   runs `bun run test:upstream-corpus` against it.
 - A scheduled GitHub Actions canary clones the latest upstream Noir repository
-  and runs the parser against the full current upstream corpus. The canary is
-  informational: it uploads a JSON report and writes a job summary so grammar
-  drift stays visible without breaking required CI.
+  and runs the parser against the full current upstream corpus. The canary
+  uploads a JSON report, writes a job summary, and fails when upstream parse
+  regressions are present.
+- A companion `upstream-canary-autofix` workflow listens for failed canary
+  runs, downloads the canary report artifact, checks out the matching upstream
+  Noir commit, and uses Codex to open a fix PR after verification passes.
 
 No upstream Noir sources are committed to this repository. The pinned manifest
 intentionally targets `examples`, `noir_stdlib`, and the success-oriented

--- a/scripts/fail-upstream-canary.js
+++ b/scripts/fail-upstream-canary.js
@@ -1,0 +1,45 @@
+const fs = require("node:fs")
+const path = require("node:path")
+
+const { parseArgs } = require("./upstream-noir")
+
+function fail(message) {
+  console.error(`::error::${message}`)
+  process.exit(1)
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const reportPath = path.resolve(
+    args.report || "tmp/upstream-canary-report.json"
+  )
+  const canaryOutcome = args["canary-outcome"] || "unknown"
+
+  if (!fs.existsSync(reportPath)) {
+    fail(
+      `Upstream canary did not produce a report (step outcome: ${canaryOutcome}).`
+    )
+  }
+
+  const report = JSON.parse(
+    fs.readFileSync(reportPath, "utf8")
+  )
+
+  if (report.failureCount > 0) {
+    fail(
+      `Upstream canary found ${report.failureCount} parse failures against ${report.commit}.`
+    )
+  }
+
+  if (canaryOutcome !== "success") {
+    fail(
+      `Upstream canary step finished with outcome ${canaryOutcome} even though the report had no parse failures.`
+    )
+  }
+
+  console.log(
+    `Upstream canary passed for ${report.commit}.`
+  )
+}
+
+main()

--- a/scripts/write-upstream-canary-summary.js
+++ b/scripts/write-upstream-canary-summary.js
@@ -1,50 +1,57 @@
-const fs = require("node:fs");
-const path = require("node:path");
+const fs = require("node:fs")
+const path = require("node:path")
 
-const { parseArgs } = require("./upstream-noir");
+const { parseArgs } = require("./upstream-noir")
 
 function main() {
-  const args = parseArgs(process.argv.slice(2));
+  const args = parseArgs(process.argv.slice(2))
   const reportPath = path.resolve(
-    args.report || "/tmp/upstream-canary-report.json"
-  );
-  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+    args.report || "tmp/upstream-canary-report.json"
+  )
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY
 
   if (!fs.existsSync(reportPath)) {
-    console.log("::warning::Upstream canary did not produce a report.");
-    return;
+    console.log(
+      "::warning::Upstream canary did not produce a report."
+    )
+    return
   }
 
-  const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
-  const successRate = ((report.successfulCount / report.fileCount) * 100).toFixed(1);
+  const report = JSON.parse(
+    fs.readFileSync(reportPath, "utf8")
+  )
+  const successRate = (
+    (report.successfulCount / report.fileCount) *
+    100
+  ).toFixed(1)
   const lines = [
     "## Upstream Noir Canary",
     "",
     `- Commit: \`${report.commit}\``,
     `- Parsed successfully: ${report.successfulCount}/${report.fileCount} (${successRate}%)`,
     `- Failures: ${report.failureCount}`,
-  ];
+  ]
 
   if (report.failures.length > 0) {
-    lines.push("");
-    lines.push("First failures:");
+    lines.push("")
+    lines.push("First failures:")
 
     for (const failure of report.failures.slice(0, 10)) {
       lines.push(
         `- \`${failure.file}\` (${failure.start.row}:${failure.start.column} - ${failure.end.row}:${failure.end.column})`
-      );
+      )
     }
 
     console.log(
       `::warning::Upstream canary found ${report.failureCount} parse failures against ${report.commit}.`
-    );
+    )
   }
 
   if (summaryPath) {
-    fs.appendFileSync(summaryPath, `${lines.join("\n")}\n`);
+    fs.appendFileSync(summaryPath, `${lines.join("\n")}\n`)
   } else {
-    console.log(lines.join("\n"));
+    console.log(lines.join("\n"))
   }
 }
 
-main();
+main()


### PR DESCRIPTION
## Summary
- bring the merged upstream canary autofix work from `chore/track-upstream-noir` onto `main`
- add the `upstream-canary-autofix` workflow and prompt files to the default branch
- keep the canary failure gate and Bun-only autofix path together on the branch GitHub actually activates

## Why
GitHub only registers and runs the scheduled/manual/workflow-run actions once the workflow files exist on the default branch. `upstream-canary.yml` is already on `main`, but `upstream-canary-autofix.yml` is still only on `chore/track-upstream-noir`.

## Contains
- `.github/workflows/upstream-canary-autofix.yml`
- `.github/codex/prompts/upstream-canary-autofix.md`
- canary failure gate and summary script updates
- docs updates for the Codex secret and workflow behavior