### PR TITLE
fix: keep upstream canary autofix local

### DIFF
--- a/.github/codex/prompts/upstream-canary-autofix.md
+++ b/.github/codex/prompts/upstream-canary-autofix.md
@@ -10,9 +10,15 @@ Start by reading:
 The workflow has already checked out the matching upstream Noir commit into
 `tmp/upstream-noir`.
 
+Important notes:
+
+- The downloaded canary report already captures the failing state from the triggering run.
+- All required context is local to this workspace. Do not fetch the failed workflow URL or browse the network.
+- If you choose to run `bun scripts/check-upstream-corpus.js --source tmp/upstream-noir --label upstream-canary --report tmp/canary-artifact/upstream-canary-report.json` before making changes, its non-zero exit is expected diagnostic output, not a blocker.
+
 Requirements:
 
-1. Reproduce the failure with `bun scripts/check-upstream-corpus.js --source tmp/upstream-noir --label upstream-canary --report tmp/canary-artifact/upstream-canary-report.json`.
+1. Use the downloaded report and the checked out upstream Noir sources to identify the smallest parser gap.
 2. Make the smallest repository changes needed so both `bun run test` and the upstream canary reproduction pass.
 3. Add or update focused corpus tests for any grammar changes.
 4. Do not edit files under `tmp/` except to regenerate the canary report during verification.

--- a/.github/workflows/upstream-canary-autofix.yml
+++ b/.github/workflows/upstream-canary-autofix.yml
@@ -98,18 +98,42 @@ jobs:
           git -C tmp/upstream-noir checkout --detach FETCH_HEAD
 
       - name: Write Codex context
+        env:
+          UPSTREAM_COMMIT: ${{ steps.report.outputs.upstream-commit }}
+          FAILURE_COUNT: ${{ steps.report.outputs.failure-count }}
         run: |
           mkdir -p tmp/codex
-          cat <<'EOF' > tmp/codex/upstream-canary-context.md
-          # Upstream Canary Context
+          node <<'EOF'
+          const fs = require("node:fs")
 
-          - Failed workflow run: ${{ env.FAILED_RUN_URL }}
-          - Base branch: `${{ env.FAILED_HEAD_BRANCH }}`
-          - Base commit: `${{ env.FAILED_HEAD_SHA }}`
-          - Upstream Noir commit: `${{ steps.report.outputs.upstream-commit }}`
-          - Reported parse failures: `${{ steps.report.outputs.failure-count }}`
-          - Report JSON: `tmp/canary-artifact/upstream-canary-report.json`
-          - Upstream checkout: `tmp/upstream-noir`
+          const report = JSON.parse(
+            fs.readFileSync("tmp/canary-artifact/upstream-canary-report.json", "utf8")
+          )
+          const lines = [
+            "# Upstream Canary Context",
+            "",
+            `- Base branch: \`${process.env.FAILED_HEAD_BRANCH}\``,
+            `- Base commit: \`${process.env.FAILED_HEAD_SHA}\``,
+            `- Upstream Noir commit: \`${process.env.UPSTREAM_COMMIT}\``,
+            `- Reported parse failures: \`${process.env.FAILURE_COUNT}\``,
+            "- Report JSON: `tmp/canary-artifact/upstream-canary-report.json`",
+            "- Upstream checkout: `tmp/upstream-noir`",
+            "- The downloaded report already captures the failing state from the triggering canary run.",
+            "- All required inputs are already local to this workspace.",
+          ]
+
+          if (report.failures.length > 0) {
+            lines.push("")
+            lines.push("First failures:")
+
+            for (const failure of report.failures.slice(0, 10)) {
+              lines.push(
+                `- \`${failure.file}\` (${failure.start.row}:${failure.start.column} - ${failure.end.row}:${failure.end.column})`
+              )
+            }
+          }
+
+          fs.writeFileSync("tmp/codex/upstream-canary-context.md", `${lines.join("\n")}\n`)
           EOF
 
       - name: Run Codex


### PR DESCRIPTION
## Summary
- build the Codex context from the downloaded canary report instead of the failed workflow URL
- include the first reported parse failures in the local context passed to Codex
- update the autofix prompt so expected pre-fix canary failures are treated as diagnostics, not task-ending blockers

## Notes
- validated the workflow YAML parses locally
- this preserves the existing behavior of attempting a fix and opening a PR when the upstream canary fails